### PR TITLE
gh-37: Added indicators for Landwirtschaft

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -62,3 +62,4 @@ dependencies:
     - OWSLib
     - pyaxis
     - XlsxWriter
+    - black

--- a/models/macros/stgn_bfs_stat_tab.sql
+++ b/models/macros/stgn_bfs_stat_tab.sql
@@ -19,6 +19,7 @@
                 , case
                     when indicator_value = '"..."' then NULL
                     when indicator_value = '"...."' then NULL
+                    when indicator_value = '"....."' then NULL
                     when indicator_value = '"......"' then NULL
                     when indicator_value = '' then NULL
                     else indicator_value::NUMERIC

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte.sql
@@ -1,0 +1,1 @@
+{{ intm_bfs_stat_tab(ref('snap_stab_lw_beschaeftigte')) }}

--- a/models/models/intermediate/intermediate.yml
+++ b/models/models/intermediate/intermediate.yml
@@ -2476,3 +2476,74 @@ models:
             filter_and:
               - column: indikator
                 exact_match: 'Vollzeitäquivalente Männer'
+
+  # ---------------------------------------------------------------------------
+  - name: intm_stab_lw_beschaeftigte
+  # ---------------------------------------------------------------------------
+    tests:
+      - odapi_intm_pk_groups
+      - odapi_intm_columns
+      - odapi_intm_rowsmin
+    config:
+      odapi:
+        indicators:
+          - indicator_id: 163
+            is_numeric: True
+            period_type: duedate
+            period_code: year
+            grouping:
+              - column: beobachtungseinheit
+                name: 'Art'
+                total_value: 'Betriebe'
+              - column: betriebssystem
+                name: 'Betriebssystem'
+                total_value: 'Betriebssystem - Total'
+            filter_and:
+              - column: beobachtungseinheit
+                regex: '^Betriebe.*'
+          - indicator_id: 164
+            is_numeric: True
+            period_type: duedate
+            period_code: year
+            build_total_value: sum(indicator_value_numeric)  # set for all groupings
+            grouping:
+              - column: beobachtungseinheit
+                name: 'Art'
+                total_value: ''
+              - column: betriebssystem
+                name: 'Betriebssystem'
+            filter_and:
+              - column: beobachtungseinheit
+                regex: '^Tiere - .*'
+              - column: betriebssystem
+                # must exclude Betriebssystem - Total, because build_total_values
+                # gets calculated for all groups
+                regex: '^(?!(Betriebssystem - Total)$)'
+          - indicator_id: 165
+            is_numeric: True
+            period_type: duedate
+            period_code: year
+            grouping:
+              - column: beobachtungseinheit
+                name: 'Art'
+                total_value: 'LN - Landwirtschaftliche Nutzfläche Total (in ha)'
+              - column: betriebssystem
+                name: 'Betriebssystem'
+                total_value: 'Betriebssystem - Total'
+            filter_and:
+              - column: beobachtungseinheit
+                regex: '^LN - .*'
+          - indicator_id: 166
+            is_numeric: True
+            period_type: duedate
+            period_code: year
+            grouping:
+              - column: beobachtungseinheit
+                name: 'Art'
+                total_value: 'Beschäftigte Total'
+              - column: betriebssystem
+                name: 'Betriebssystem'
+                total_value: 'Betriebssystem - Total'
+            filter_and:
+              - column: beobachtungseinheit
+                regex: '^Beschäftigte.*'

--- a/models/models/marts/mart_ogd_api.sql
+++ b/models/models/marts/mart_ogd_api.sql
@@ -222,3 +222,5 @@ UNION ALL
 select * from {{ ref('intm_stab_wirtschaft_unternehmen')}}
 UNION ALL
 select * from {{ ref('intm_stab_wirtschaft_beschaeftigte')}}
+UNION ALL
+select * from {{ ref('intm_stab_lw_beschaeftigte')}}

--- a/models/models/schema.yml
+++ b/models/models/schema.yml
@@ -34,6 +34,7 @@ sources:
       - name: stat_tab_arbeit_grenzgaenger
       - name: stat_tab_wirtschaft_unternehmen
       - name: stat_tab_wirtschaft_beschaeftigte
+      - name: stat_tab_lw_beschaeftigte
   - name: ktzh_gwr
     database: data
     schema: src

--- a/models/models/staging/staging.yml
+++ b/models/models/staging/staging.yml
@@ -256,3 +256,15 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns: ['_surr_key']
+
+  # ---------------------------------------------------------------------------
+  - name: stgn_stab_lw_beschaeftigte
+  # ---------------------------------------------------------------------------
+    config:
+      odapi:
+        grouping_columns:
+          - beobachtungseinheit
+          - betriebssystem
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ['_surr_key']

--- a/models/models/staging/stgn_stab_lw_beschaeftigte.sql
+++ b/models/models/staging/stgn_stab_lw_beschaeftigte.sql
@@ -1,0 +1,4 @@
+-- depends_on: {{ ref('dim_gemeinde_latest') }}
+{{ stgn_bfs_stat_tab(source('src', 'stat_tab_lw_beschaeftigte')) }}
+
+select * from final

--- a/models/seeds/seed_indicator.csv
+++ b/models/seeds/seed_indicator.csv
@@ -161,3 +161,7 @@ indicator_id,indicator_name,topic_1,topic_2,topic_3,topic_4,indicator_unit,indic
 160,"Vollzeitäquivalente, nach Sektor",06 Industrie & Dienstleistungen,06.01 Beschäftigte,,,Vollzeitäquivalente,Zahl der Vollzeitäquivalente der Beschäftigten
 161,"Vollzeitäquivalente Frauen, nach Sektor",06 Industrie & Dienstleistungen,06.01 Beschäftigte,,,Vollzeitäquivalente,Zahl der Vollzeitäquivalente der Beschäftigten
 162,"Vollzeitäquivalente Männer, nach Sektor",06 Industrie & Dienstleistungen,06.01 Beschäftigte,,,Vollzeitäquivalente,Zahl der Vollzeitäquivalente der Beschäftigten
+163,"Landwirtschaftliche Betriebe, nach Art und Betriebssystem",07 Land- & Forstwirtschaft,07.01 Betriebe,,,Anzahl,Anzahl der landwirtschaftlichen Betriebe
+164,"Tiere in landwirtschaftlichen Betrieben, nach Art und Betriebssystem",07 Land- & Forstwirtschaft,07.02 Tiere,,,Anzahl,Anzahl der Tiere
+165,"Landwirtschaftliche Nutzfläche (LN), nach Art und Betriebssystem",07 Land- & Forstwirtschaft,07.03 Landwirtschaftliche Nutzfläche,,,Hektar,Landwirtschaftliche Nutzfläche in Hektar
+166,"Beschäftigte in landwirtschaftlichen Betrieben, nach Art und Betriebssystem",07 Land- & Forstwirtschaft,07.04 Beschäftigte,,,Anzahl,Anzahl Beschäftigte in landwirtschaftlichen Betrieben

--- a/models/snapshots/snap_stab_lw_beschaeftigte.sql
+++ b/models/snapshots/snap_stab_lw_beschaeftigte.sql
@@ -1,0 +1,18 @@
+{% snapshot snap_stab_lw_beschaeftigte %}
+{{
+    config(
+        target_schema='snapshots',
+        strategy='check',
+        unique_key='_surr_key',
+        check_cols=[
+            'beobachtungseinheit',
+            'betriebssystem'
+        ],
+        invalidate_hard_deletes=True,
+    )
+}}
+
+select *
+from {{ ref('stgn_stab_lw_beschaeftigte') }}
+
+{% endsnapshot %}

--- a/models/snapshots/snapshots.yml
+++ b/models/snapshots/snapshots.yml
@@ -152,3 +152,10 @@ snapshots:
       - dbt_utils.unique_combination_of_columns:  # test strict PK
           combination_of_columns: ['_surr_key', 'dbt_valid_from']
 
+  # ---------------------------------------------------------------------------
+  - name: snap_stab_lw_beschaeftigte
+  # ---------------------------------------------------------------------------
+    tests:
+      - dbt_utils.unique_combination_of_columns:  # test strict PK
+          combination_of_columns: ['_surr_key', 'dbt_valid_from']
+


### PR DESCRIPTION
Added indicators for the Landwirtschaftliche Strukturerhebung.

Additionally, modified macro `intm_bfs_stat_tab`:
Before the change, if any `build_total_value` was set in the config of a indicator in the mart, all indicators were treated as if they need a calulation for the GROUP TOTAL. This is now determined for every indicator individually.