### PR TITLE
Refactor INTM

### DIFF
--- a/create_intm_dunder_models.sh
+++ b/create_intm_dunder_models.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Script to scan models/models/intermediate for SQL files without "__" in their name
+# and generate corresponding __measure.sql, __typecast.sql, and mart_*.sql files.
+
+BASE_DIR="models/models/intermediate"
+MARTS_DIR="models/models/marts"
+
+# Ensure marts directory exists
+mkdir -p "$MARTS_DIR"
+
+# Find .sql files not containing "__" in the filename
+find "$BASE_DIR" -type f -name "*.sql" ! -name "*__*.sql" | while read -r file; do
+    # Remove .sql extension
+    base="${file%.sql}"
+
+    # Define new filenames in intermediate
+    measure_file="${base}__measure.sql"
+    typecast_file="${base}__typecast.sql"
+
+    # Create files with the requested content
+    echo "{{ intm_measures() }}" > "$measure_file"
+    echo "{{ intm_typecast() }}" > "$typecast_file"
+
+    echo "Created: $measure_file"
+    echo "Created: $typecast_file"
+
+    # Create mart file
+    filename=$(basename "$file")       # e.g. intm_orders.sql
+    mart_filename="${filename/intm_/mart_}"  # replace prefix
+    mart_file="$MARTS_DIR/$mart_filename"
+
+    echo "{{ mart_partition() }}" > "$mart_file"
+    echo "Created: $mart_file"
+done
+

--- a/dag/odapi/assets/py_intermediate/intm_meta_group.py
+++ b/dag/odapi/assets/py_intermediate/intm_meta_group.py
@@ -10,7 +10,9 @@ from sqlalchemy import text
 
 from odapi.resources.postgres.postgres import PostgresResource
 from odapi.resources.qa.great_expectations import GreatExpectationsResource
-from odapi.utils.dbt_handling import load_intm_data_models
+from odapi.utils.dbt_handling import load_data_models
+
+MODEL_SEARCH_PATTERN = r'^(?!.*__\w+$)intm_.*$'
 
 
 @asset(
@@ -20,7 +22,9 @@ from odapi.utils.dbt_handling import load_intm_data_models
     description=f"INTM model to dynamically compose SQL for selecting groups from INTM.",
     deps=[
         AssetKey(['intermediate', model.model_name])
-        for model in load_intm_data_models()
+        for model in load_data_models(
+            pattern=MODEL_SEARCH_PATTERN, dbt_group='intermediate'
+        )
     ],
 )
 def _asset(
@@ -38,7 +42,9 @@ def _asset(
                 , group_4_name
             from {model.relation_name}\n
         """
-            for model in load_intm_data_models()
+            for model in load_data_models(
+                pattern=MODEL_SEARCH_PATTERN, dbt_group='intermediate'
+            )
         ]
         src_select = 'UNION \n'.join(selects)
         return f"""

--- a/dag/odapi/assets/py_intermediate/intm_meta_group_value.py
+++ b/dag/odapi/assets/py_intermediate/intm_meta_group_value.py
@@ -11,7 +11,9 @@ from sqlalchemy import text
 
 from odapi.resources.postgres.postgres import PostgresResource
 from odapi.resources.qa.great_expectations import GreatExpectationsResource
-from odapi.utils.dbt_handling import load_intm_data_models
+from odapi.utils.dbt_handling import load_data_models
+
+MODEL_SEARCH_PATTERN = r'^(?!.*__\w+$)intm_.*$'
 
 
 @asset(
@@ -21,7 +23,9 @@ from odapi.utils.dbt_handling import load_intm_data_models
     description=f"INTM model to dynamically compose SQL for selecting group values from INTM.",
     deps=[
         AssetKey(['intermediate', model.model_name])
-        for model in load_intm_data_models()
+        for model in load_data_models(
+            pattern=MODEL_SEARCH_PATTERN, dbt_group='intermediate'
+        )
     ],
 )
 def _asset(
@@ -39,7 +43,9 @@ def _asset(
                 , group_4_value
             from {model.relation_name}\n
         """
-            for model in load_intm_data_models()
+            for model in load_data_models(
+                pattern=MODEL_SEARCH_PATTERN, dbt_group='intermediate'
+            )
         ]
         src_select = 'UNION \n'.join(selects)
         return f"""

--- a/dba_index_usage.txt
+++ b/dba_index_usage.txt
@@ -1,0 +1,28 @@
+data=#
+SELECT
+    idx.relname AS index_name,
+    string_agg(col.attname, ', ' ORDER BY x.ordinality) AS indexed_columns,
+    pg_size_pretty(pg_relation_size(idx.oid)) AS index_size,
+    ui.idx_scan,
+    ui.idx_tup_read,
+    ui.idx_tup_fetch
+FROM
+    pg_stat_user_indexes ui
+JOIN
+    pg_index i ON ui.indexrelid = i.indexrelid
+JOIN
+    pg_class idx ON idx.oid = ui.indexrelid
+JOIN
+    pg_class tbl ON tbl.oid = ui.relid
+JOIN
+    LATERAL unnest(i.indkey) WITH ORDINALITY AS x(attnum, ordinality) ON true
+JOIN
+    pg_attribute col ON col.attnum = x.attnum
+                    AND col.attrelid = tbl.oid
+WHERE
+    tbl.relname = 'mart_ogd_api'
+GROUP BY
+    idx.relname, idx.oid, ui.idx_scan, ui.idx_tup_read, ui.idx_tup_fetch
+ORDER BY
+    ui.idx_scan DESC, index_size DESC;
+

--- a/models/dbt_project.yml
+++ b/models/dbt_project.yml
@@ -1,13 +1,12 @@
-
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'odapi'
-version: '1.0.0'
+name: "odapi"
+version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: 'odapi'
+profile: "odapi"
 
 # These configurations specify where dbt should look for different types of files.
 # The `model-paths` config, for example, states that models in this project can be
@@ -19,10 +18,9 @@ seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-clean-targets:         # directories to be removed by `dbt clean`
+clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
-
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
@@ -49,13 +47,11 @@ models:
       +materialized: table
       +schema: intermediate_meta
       +group: intermediate_meta
-    # TODO: Make view (with exception of heavy calculation models like dim_gemiende)
-    # to save storage.
     intermediate:
-      +materialized: table
+      +materialized: view
       +schema: intermediate
       +group: intermediate
     marts:
       +materialized: table
       +schema: marts
-
+      +group: marts

--- a/models/macros/intm_bfs_stat_tab.sql
+++ b/models/macros/intm_bfs_stat_tab.sql
@@ -230,47 +230,16 @@
         {% endfor %}
     )
 
-    , final as (
-        select
-            *
-            , 1 as _etl_version
-        from set_names_for_group_totals
-        where
-            1=1
-            -- global filters
-            AND geo_code = 'polg' AND geo_value is not NULL -- can be extended later
-            AND (indicator_value_numeric is not NULL or indicator_value_text is not NULL)
-    )
-
-    {% set measure_config = config.require('odapi').get('measure', none) %}
-    {% if measure_config is none %}
-        select
-            indicator_id
-            , geo_code
-            , geo_value
-            , knowledge_date_from
-            , knowledge_date_to
-            , period_type
-            , period_code
-            , period_ref_from
-            , period_ref
-            , group_1_name
-            , group_1_value
-            , group_2_name
-            , group_2_value
-            , group_3_name
-            , group_3_value
-            , group_4_name
-            , group_4_value
-            , indicator_value_numeric
-            , indicator_value_text
-            , source
-            , _etl_version
-            , 'zahl' as measure_code
-        from final
-    {% endif %}
+    select
+        *
+        , 1 as _etl_version
+    from set_names_for_group_totals
+    where
+        1=1
+        -- global filters
+        AND geo_code = 'polg' AND geo_value is not NULL -- can be extended later
+        AND (indicator_value_numeric is not NULL or indicator_value_text is not NULL)
 
     {% endif %}
-
 
 {% endmacro %}

--- a/models/macros/intm_bfs_statatlas.sql
+++ b/models/macros/intm_bfs_statatlas.sql
@@ -273,31 +273,33 @@ with _dummy as (
 {% if execute %}
     {% set measure_config = config.require('odapi').get('measure', none) %}
 {% endif %}
+
+select
+    meas.indicator_id::SMALLINT
+    , meas.geo_code::CHAR(4)
+    , meas.geo_value::SMALLINT
+    , meas.knowledge_date_from::TIMESTAMP WITHOUT TIME ZONE
+    , meas.knowledge_date_to::TIMESTAMP WITHOUT TIME ZONE
+    , meas.period_type::TEXT
+    , meas.period_code::TEXT
+    , meas.period_ref_from::DATE
+    , meas.period_ref::DATE
+    , meas.group_1_name::TEXT
+    , meas.group_1_value::TEXT
+    , meas.group_2_name::TEXT
+    , meas.group_2_value::TEXT
+    , meas.group_3_name::TEXT
+    , meas.group_3_value::TEXT
+    , meas.group_4_name::TEXT
+    , meas.group_4_value::TEXT
+    , meas.indicator_value_numeric::NUMERIC
+    , meas.indicator_value_text::TEXT
+    , meas.source::TEXT
+    , meas._etl_version::SMALLINT
 {% if measure_config is none %}
-    select
-        meas.indicator_id::SMALLINT
-        , meas.geo_code::CHAR(4)
-        , meas.geo_value::SMALLINT
-        , meas.knowledge_date_from::TIMESTAMP WITHOUT TIME ZONE
-        , meas.knowledge_date_to::TIMESTAMP WITHOUT TIME ZONE
-        , meas.period_type::TEXT
-        , meas.period_code::TEXT
-        , meas.period_ref_from::DATE
-        , meas.period_ref::DATE
-        , meas.group_1_name::TEXT
-        , meas.group_1_value::TEXT
-        , meas.group_2_name::TEXT
-        , meas.group_2_value::TEXT
-        , meas.group_3_name::TEXT
-        , meas.group_3_value::TEXT
-        , meas.group_4_name::TEXT
-        , meas.group_4_value::TEXT
-        , meas.indicator_value_numeric::NUMERIC
-        , meas.indicator_value_text::TEXT
-        , meas.source::TEXT
-        , meas._etl_version::SMALLINT
-        , 'zahl'::TEXT as measure_code
     from final meas
+{% else %}
+    from keep_only_one_row_v1_v2 meas
 {% endif %}
 
 {% endmacro %}

--- a/models/macros/intm_get_upstream_config.sql
+++ b/models/macros/intm_get_upstream_config.sql
@@ -1,0 +1,25 @@
+{% macro intm_get_upstream_config() %}
+  {% set current_model_name = model.name %}
+
+  {# strip off everything after the first "__" #}
+  {% set base_model_name = current_model_name.split('__')[0] %}
+
+  {# look up the base model node in the graph #}
+  {% set node = graph.nodes.get(ref(base_model_name).unique_id) %}
+
+  {% set candidates = [] %}
+  {% for n in graph.nodes.values() %}
+    {% if n.resource_type == 'model' and n.name == base_model_name %}
+      {% do candidates.append(n) %}
+    {% endif %}
+  {% endfor %}
+  {% if candidates | length == 1 %}
+    {% set node = candidates[0] %}
+  {% else %}
+    {% do exceptions.raise_compiler_error("intm_get_upstream_config: Could not find upstream model '" ~ base ~ "'.") %}
+  {% endif %}
+
+  {# return its meta config (or empty dict if missing) #}
+  {{ print(node) }}
+  {{ return(node.config or {}) }}
+{% endmacro %}

--- a/models/macros/intm_ktzh_gp.sql
+++ b/models/macros/intm_ktzh_gp.sql
@@ -61,7 +61,6 @@
             , NULL::TEXT as indicator_value_text
             , 'Gemeindeportrait des Kantons Zürich' as source
             , 1 as _etl_version
-            , 'zahl' as measure_code
         from src
     )
     select
@@ -86,6 +85,5 @@
         , meas.indicator_value_text::TEXT
         , meas.source::TEXT
         , meas._etl_version::SMALLINT
-        , meas.measure_code::TEXT
     from mapping meas
 {% endmacro %}

--- a/models/macros/intm_typecast.sql
+++ b/models/macros/intm_typecast.sql
@@ -1,0 +1,30 @@
+{% macro intm_typecast(upstream_model) %}
+    
+    {% set upstream_model_name = model.name.split('__')[0] ~ '__measure' %}
+
+    select 
+        intm.indicator_id::SMALLINT
+        , intm.geo_code::CHAR(4)
+        , intm.geo_value::SMALLINT
+        , intm.knowledge_date_from::TIMESTAMP WITHOUT TIME ZONE
+        , intm.knowledge_date_to::TIMESTAMP WITHOUT TIME ZONE
+        , intm.period_type::TEXT
+        , intm.period_code::TEXT
+        , intm.period_ref_from::DATE
+        , intm.period_ref::DATE
+        , intm.group_1_name::TEXT
+        , intm.group_1_value::TEXT
+        , intm.group_2_name::TEXT
+        , intm.group_2_value::TEXT
+        , intm.group_3_name::TEXT
+        , intm.group_3_value::TEXT
+        , intm.group_4_name::TEXT
+        , intm.group_4_value::TEXT
+        , intm.indicator_value_numeric::NUMERIC
+        , intm.indicator_value_text::TEXT
+        , intm.source::TEXT
+        , intm._etl_version::SMALLINT
+        , intm.measure_code::TEXT
+    from {{ ref(upstream_model_name) }} intm
+
+{% endmacro %}

--- a/models/macros/mart_partition.sql
+++ b/models/macros/mart_partition.sql
@@ -1,0 +1,65 @@
+{% macro mart_partition() %}
+
+    {%- set base_name = modules.re.sub('__.*$', '', model.name) -%}
+    {%- set upstream_model_name = modules.re.sub('^mart_', 'intm_', base_name) ~ '__typecast' -%}
+
+    with replace_with_ids as (
+        select
+            -- replacements of text to ids happen here
+            -- so that it uses less storage and gets persisted as table
+            indicator_id
+            , geo_code
+            , geo_value
+            , knowledge_date_from
+            , knowledge_date_to
+            , period_type
+            , period_code
+            , period_ref_from
+            , period_ref
+            , group_1.group_id as group_1_id
+            , group_value_1.group_value_id as group_value_1_id
+            , case
+                when coalesce(group_value_1.group_value_id, 1) = 1 then TRUE
+                else FALSE
+            end as _group_value_1_is_total
+            , group_2.group_id as group_2_id
+            , group_value_2.group_value_id as group_value_2_id
+            , case
+                when coalesce(group_value_2.group_value_id, 1) = 1 then TRUE
+                else FALSE
+            end as _group_value_2_is_total
+            , group_3.group_id as group_3_id
+            , group_value_3.group_value_id as group_value_3_id
+            , case
+                when coalesce(group_value_3.group_value_id, 1) = 1 then TRUE
+                else FALSE
+            end as _group_value_3_is_total
+            , group_4.group_id as group_4_id
+            , group_value_4.group_value_id as group_value_4_id
+            , case
+                when coalesce(group_value_4.group_value_id, 1) = 1 then TRUE
+                else FALSE
+            end as _group_value_4_is_total
+            , measure_code
+            , indicator_value_numeric::NUMERIC(32, 9)  -- this is a limit from COPY TO PARQUET
+            , indicator_value_text
+            , dim.id as source_id
+        from {{ ref(upstream_model_name) }} src
+            left join {{ ref('dim_source') }} dim on src.source = dim.source
+            left join {{ ref('dim_group') }} group_1 on src.group_1_name = group_1.group_name
+            left join {{ ref('dim_group') }} group_2 on src.group_2_name = group_2.group_name
+            left join {{ ref('dim_group') }} group_3 on src.group_3_name = group_3.group_name
+            left join {{ ref('dim_group') }} group_4 on src.group_4_name = group_4.group_name
+            left join {{ ref('dim_group_value') }} group_value_1 on
+                src.group_1_value = group_value_1.group_value_name
+            left join {{ ref('dim_group_value') }} group_value_2 on
+                src.group_2_value = group_value_2.group_value_name
+            left join {{ ref('dim_group_value') }} group_value_3 on
+                src.group_3_value = group_value_3.group_value_name
+            left join {{ ref('dim_group_value') }} group_value_4 on
+                src.group_4_value = group_value_4.group_value_name
+    )
+
+    select * from replace_with_ids
+
+{% endmacro %}

--- a/models/models/intermediate/bfe/intm_bfe_minergie.sql
+++ b/models/models/intermediate/bfe/intm_bfe_minergie.sql
@@ -189,12 +189,11 @@ with src as (
         , NULL::TEXT as indicator_value_text
         , source
         , 1::SMALLINT as _etl_version
-        , 'zahl' as measure_code
     from union_all
 )
 
 
-select 
+select
     meas.indicator_id::SMALLINT
     , meas.geo_code::CHAR(4)
     , meas.geo_value::SMALLINT
@@ -216,5 +215,4 @@ select
     , meas.indicator_value_text::TEXT
     , meas.source::TEXT
     , meas._etl_version::SMALLINT
-    , meas.measure_code::TEXT
 from final meas

--- a/models/models/intermediate/bfe/intm_bfe_minergie__measure.sql
+++ b/models/models/intermediate/bfe/intm_bfe_minergie__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfe/intm_bfe_minergie__typecast.sql
+++ b/models/models/intermediate/bfe/intm_bfe_minergie__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_arbeit_grenzgaenger.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_arbeit_grenzgaenger.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_arbeit_grenzgaenger')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_arbeit_grenzgaenger__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_arbeit_grenzgaenger__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_arbeit_grenzgaenger__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_arbeit_grenzgaenger__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bau_ausgaben.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bau_ausgaben.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bau_ausgaben')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bau_ausgaben__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bau_ausgaben__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bau_ausgaben__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bau_ausgaben__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_altersklasse.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_altersklasse.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bev_altersklasse')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_altersklasse__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_altersklasse__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_altersklasse__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_altersklasse__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_demografisch_bilanz.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_demografisch_bilanz.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bev_demografie_bilanz')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_demografisch_bilanz__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_demografisch_bilanz__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_demografisch_bilanz__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_demografisch_bilanz__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_geburtsort.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_geburtsort.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bev_geburtsort')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_geburtsort__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_geburtsort__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_geburtsort__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_geburtsort__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_heirat.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_heirat.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bev_heirat')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_heirat__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_heirat__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_heirat__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_heirat__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_scheidung.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_scheidung.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bev_scheidung')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_scheidung__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_scheidung__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_scheidung__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_scheidung__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zivilstand.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zivilstand.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bev_zivilstand')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zivilstand__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zivilstand__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zivilstand__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zivilstand__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zuwegzug.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zuwegzug.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_bev_zuwegzug')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zuwegzug__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zuwegzug__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zuwegzug__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_bev_zuwegzug__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_bestand.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_bestand.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_geb_bestand')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_bestand__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_bestand__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_bestand__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_bestand__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_flaeche.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_flaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_geb_flaeche')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_flaeche__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_flaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_flaeche__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_flaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_leerwhg.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_leerwhg.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_geb_leerwhg')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_leerwhg__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_leerwhg__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_geb_leerwhg__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_geb_leerwhg__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_lw_beschaeftigte')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_lw_beschaeftigte__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_raum_areal.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_raum_areal.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_raum_areal')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_raum_areal__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_raum_areal__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_raum_areal__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_raum_areal__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_raum_noas.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_raum_noas.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_raum_noas')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_raum_noas__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_raum_noas__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_raum_noas__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_raum_noas__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_beschaeftigte.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_beschaeftigte.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_wirtschaft_beschaeftigte')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_beschaeftigte__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_beschaeftigte__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_beschaeftigte__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_beschaeftigte__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_unternehmen.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_unternehmen.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_stat_tab(ref('snap_stab_wirtschaft_unternehmen')) }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_unternehmen__measure.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_unternehmen__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_unternehmen__typecast.sql
+++ b/models/models/intermediate/bfs/stat_tab/intm_stab_wirtschaft_unternehmen__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_0019jahre.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_0019jahre.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_0019jahre__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_0019jahre__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_0019jahre__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_0019jahre__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2039jahre.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2039jahre.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2039jahre__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2039jahre__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2039jahre__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2039jahre__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2064jahre.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2064jahre.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2064jahre__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2064jahre__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2064jahre__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_2064jahre__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_65plusjahre.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_65plusjahre.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_65plusjahre__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_65plusjahre__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_65plusjahre__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_65plusjahre__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_altersquotient.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_altersquotient.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_altersquotient__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_altersquotient__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_altersquotient__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_altersquotient__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_gesamtquotient.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_gesamtquotient.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_gesamtquotient__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_gesamtquotient__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_gesamtquotient__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_gesamtquotient__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_greyingindex.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_greyingindex.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_greyingindex__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_greyingindex__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_greyingindex__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_greyingindex__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_jugendquotient.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_jugendquotient.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_jugendquotient__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_jugendquotient__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_jugendquotient__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_altersstruktur_jugendquotient__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_kultur.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_kultur.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_kultur__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_kultur__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_kultur__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_kultur__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor1.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor1.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor1__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor1__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor1__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor1__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor2.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor2.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor2__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor2__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor2__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor2__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor3.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor3.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor3__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor3__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor3__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_arbeitsstaetten_sektor3__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaender_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaender_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaender_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaender_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaender_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaender_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_deutsche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_deutsche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_deutsche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_deutsche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_deutsche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_deutsche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_eu.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_eu.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_eu__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_eu__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_eu__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_eu__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_franzoesisch.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_franzoesisch.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_franzoesisch__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_franzoesisch__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_franzoesisch__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_franzoesisch__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_staendig.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_staendig.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_staendig__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_staendig__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_staendig__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_auslaenderanteil_staendig__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_gebaeude_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_gebaeude_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_gebaeude_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_gebaeude_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_gebaeude_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_gebaeude_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_wohnung_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_wohnung_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_wohnung_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_wohnung_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_wohnung_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bau_wohnung_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_betriebswirtschaft.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_betriebswirtschaft.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_betriebswirtschaft__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_betriebswirtschaft__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_betriebswirtschaft__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_betriebswirtschaft__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_kultur.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_kultur.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_kultur__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_kultur__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_kultur__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_kultur__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor1.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor1.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor1__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor1__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor1__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor1__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor2.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor2.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor2__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor2__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor2__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor2__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor3.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor3.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor3__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor3__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor3__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_beschaeftigte_sektor3__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_arbeitsplaetze.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_arbeitsplaetze.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_arbeitsplaetze__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_arbeitsplaetze__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_arbeitsplaetze__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_arbeitsplaetze__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_unternehmen.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_unternehmen.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_unternehmen__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_unternehmen__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_unternehmen__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bestand_unternehmen__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_gesamt.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_gesamt.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_gesamt__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_gesamt__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_gesamt__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_gesamt__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_produktiv.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_produktiv.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_produktiv__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_produktiv__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_produktiv__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bevoelkerungsdichte_produktiv__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bewohner_efh.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bewohner_efh.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bewohner_efh__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bewohner_efh__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bewohner_efh__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_bewohner_efh__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_biblio.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_biblio.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_biblio__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_biblio__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_biblio__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_biblio__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_binnen_wanderungssaldo_p1000.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_binnen_wanderungssaldo_p1000.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_binnen_wanderungssaldo_p1000__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_binnen_wanderungssaldo_p1000__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_binnen_wanderungssaldo_p1000__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_binnen_wanderungssaldo_p1000__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_efh.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_efh.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_efh__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_efh__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_efh__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_efh__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einbuergerungen_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einwohner_staendig.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einwohner_staendig.sql
@@ -1,3 +1,2 @@
 {{ intm_bfs_statatlas() }}
--- cannot add intm_measures() here because of
 -- otherwise circular dependency

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einwohner_staendig__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einwohner_staendig__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einwohner_staendig__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_einwohner_staendig__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anteil.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anteil.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anteil__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anteil__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anteil__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anteil__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_elektroautos_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_energiequelle__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_energiequelle__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_energiequelle__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_energiequelle__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_gas.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_gas.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_gas__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_gas__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_gas__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_gas__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_heizoel.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_heizoel.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_heizoel__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_heizoel__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_heizoel__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_heizoel__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_waermepumpe.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_waermepumpe.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_waermepumpe__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_waermepumpe__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_waermepumpe__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geb_waermepumpe__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gebaeudeareal_gesamt.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gebaeudeareal_gesamt.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gebaeudeareal_gesamt__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gebaeudeareal_gesamt__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gebaeudeareal_gesamt__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gebaeudeareal_gesamt__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburten.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburten.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburten__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburten__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburten__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburten__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburtenueberschuss.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburtenueberschuss.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburtenueberschuss__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburtenueberschuss__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburtenueberschuss__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_geburtenueberschuss__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gymi_anteil.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gymi_anteil.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gymi_anteil__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gymi_anteil__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gymi_anteil__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_gymi_anteil__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_1pax.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_1pax.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_1pax__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_1pax__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_1pax__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_1pax__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_2pax.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_2pax.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_2pax__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_2pax__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_2pax__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_2pax__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_3pax.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_3pax.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_3pax__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_3pax__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_3pax__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_3pax__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_4pax.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_4pax.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_4pax__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_4pax__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_4pax__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_4pax__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_5pluspax.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_5pluspax.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_5pluspax__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_5pluspax__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_5pluspax__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushalt_5pluspax__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushaltsgroesse.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushaltsgroesse.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushaltsgroesse__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushaltsgroesse__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushaltsgroesse__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_haushaltsgroesse__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_heiraten_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_heiraten_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_heiraten_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_heiraten_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_heiraten_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_heiraten_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_industrieareal.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_industrieareal.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_industrieareal__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_industrieareal__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_industrieareal__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_industrieareal__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_int_wanderungssaldo_p1000.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_int_wanderungssaldo_p1000.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_int_wanderungssaldo_p1000__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_int_wanderungssaldo_p1000__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_int_wanderungssaldo_p1000__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_int_wanderungssaldo_p1000__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kino_sitzplaetze.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kino_sitzplaetze.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kino_sitzplaetze__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kino_sitzplaetze__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kino_sitzplaetze__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kino_sitzplaetze__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinokomplexe.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinokomplexe.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinokomplexe__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinokomplexe__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinokomplexe__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinokomplexe__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinos.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinos.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinos__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinos__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinos__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinos__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele_3d.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele_3d.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele_3d__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele_3d__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele_3d__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele_3d__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kinosaele__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kuenstlich_angelegt.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kuenstlich_angelegt.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kuenstlich_angelegt__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kuenstlich_angelegt__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kuenstlich_angelegt__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_kuenstlich_angelegt__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_landwirtschaftsflaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_landwirtschaftsflaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_landwirtschaftsflaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_landwirtschaftsflaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_landwirtschaftsflaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_landwirtschaftsflaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_lwz.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_lwz.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_lwz__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_lwz__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_lwz__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_lwz__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_multiplexkino.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_multiplexkino.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_multiplexkino__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_multiplexkino__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_multiplexkino__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_multiplexkino__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_museen.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_museen.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_museen__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_museen__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_museen__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_museen__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_arbeitsplaetze.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_arbeitsplaetze.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_arbeitsplaetze__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_arbeitsplaetze__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_arbeitsplaetze__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_arbeitsplaetze__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_unternehmen.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_unternehmen.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_unternehmen__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_unternehmen__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_unternehmen__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_neu_unternehmen__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_bilanz.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_bilanz.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_bilanz__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_bilanz__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_bilanz__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_bilanz__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_saldo.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_saldo.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_saldo__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_saldo__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_saldo__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_pendler_saldo__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_scheidungen_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_scheidungen_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_scheidungen_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_scheidungen_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_scheidungen_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_scheidungen_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_arbeitsplaetze.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_arbeitsplaetze.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_arbeitsplaetze__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_arbeitsplaetze__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_arbeitsplaetze__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_arbeitsplaetze__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_unternehmen.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_unternehmen.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_unternehmen__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_unternehmen__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_unternehmen__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_schliessung_unternehmen__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_siedlungsflaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_siedlungsflaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_siedlungsflaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_siedlungsflaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_siedlungsflaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_siedlungsflaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_sozialhilfe_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_sozialhilfe_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_sozialhilfe_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_sozialhilfe_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_sozialhilfe_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_sozialhilfe_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_einwohner.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_einwohner.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_einwohner__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_einwohner__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_einwohner__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_einwohner__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_steuerpflichtig.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_steuerpflichtig.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_steuerpflichtig__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_steuerpflichtig__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_steuerpflichtig__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_steuerpflichtig__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_total.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_total.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_total__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_total__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_total__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_reineinkommen_total__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_einwohner.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_einwohner.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_einwohner__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_einwohner__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_einwohner__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_einwohner__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_steuerpflichtig.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_steuerpflichtig.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_steuerpflichtig__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_steuerpflichtig__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_steuerpflichtig__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_steuerpflichtig__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_total.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_total.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_total__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_total__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_total__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_tax_steuerbar_total__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_todesfaelle_anzahl.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_todesfaelle_anzahl.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_todesfaelle_anzahl__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_todesfaelle_anzahl__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_todesfaelle_anzahl__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_todesfaelle_anzahl__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_unproduktivflaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_unproduktivflaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_unproduktivflaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_unproduktivflaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_unproduktivflaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_unproduktivflaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_vegetationslose_flaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_vegetationslose_flaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_vegetationslose_flaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_vegetationslose_flaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_vegetationslose_flaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_vegetationslose_flaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_verkehrsflaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_verkehrsflaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_verkehrsflaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_verkehrsflaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_verkehrsflaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_verkehrsflaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_versiegelte_flaeche_anteil.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_versiegelte_flaeche_anteil.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_versiegelte_flaeche_anteil__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_versiegelte_flaeche_anteil__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_versiegelte_flaeche_anteil__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_versiegelte_flaeche_anteil__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_waldflaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_waldflaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_waldflaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_waldflaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_waldflaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_waldflaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wanderungssaldo_p1000.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wanderungssaldo_p1000.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wanderungssaldo_p1000__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wanderungssaldo_p1000__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wanderungssaldo_p1000__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wanderungssaldo_p1000__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wasserflaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wasserflaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wasserflaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wasserflaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wasserflaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wasserflaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_energiequelle__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_energiequelle__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_energiequelle__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_energiequelle__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_gas.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_gas.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_gas__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_gas__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_gas__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_gas__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_heizoel.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_heizoel.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_heizoel__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_heizoel__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_heizoel__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_heizoel__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_waermepumpe.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_waermepumpe.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_waermepumpe__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_waermepumpe__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_waermepumpe__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_whg_waermepumpe__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wohnflaeche.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wohnflaeche.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wohnflaeche__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wohnflaeche__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wohnflaeche__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_wohnflaeche__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_zi34.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_zi34.sql
@@ -1,2 +1,1 @@
 {{ intm_bfs_statatlas() }}
-{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_zi34__measure.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_zi34__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_zi34__typecast.sql
+++ b/models/models/intermediate/bfs/statatlas/intm_bfs_statatlas_zi34__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/estv/intm_estv_db_jp.sql
+++ b/models/models/intermediate/estv/intm_estv_db_jp.sql
@@ -28,7 +28,6 @@ with src as (
         , NULL::TEXT as indicator_value_text
         , 'Eidgenössische Steuerverwaltung ESTV' as source
         , 1 as _etl_version
-        , 'zahl' as measure_code
     from {{ ref('stgn_estv_db_jp') }}
     where
         quartile is NULL  -- Maybe change later
@@ -55,6 +54,5 @@ select
     , meas.indicator_value_text::TEXT
     , meas.source::TEXT
     , meas._etl_version::SMALLINT
-    , meas.measure_code::TEXT
 from src meas
 where indicator_id is not NULL

--- a/models/models/intermediate/estv/intm_estv_db_jp__measure.sql
+++ b/models/models/intermediate/estv/intm_estv_db_jp__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/estv/intm_estv_db_jp__typecast.sql
+++ b/models/models/intermediate/estv/intm_estv_db_jp__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/estv/intm_estv_db_np.sql
+++ b/models/models/intermediate/estv/intm_estv_db_np.sql
@@ -42,7 +42,6 @@ with src as (
         , NULL::TEXT as indicator_value_text
         , 'Eidgenössische Steuerverwaltung ESTV' as source
         , 1 as _etl_version
-        , 'zahl' as measure_code
     from {{ ref('stgn_estv_db_np') }}
     where
         zivilstand = 'T'  -- Maybe extend later
@@ -71,6 +70,5 @@ select
     , meas.indicator_value_text::TEXT
     , meas.source::TEXT
     , meas._etl_version::SMALLINT
-    , meas.measure_code::TEXT
 from src meas
 where indicator_id is not NULL

--- a/models/models/intermediate/estv/intm_estv_db_np__measure.sql
+++ b/models/models/intermediate/estv/intm_estv_db_np__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/estv/intm_estv_db_np__typecast.sql
+++ b/models/models/intermediate/estv/intm_estv_db_np__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/intermediate.yml
+++ b/models/models/intermediate/intermediate.yml
@@ -11,6 +11,8 @@ models:
         - columns: [geo_code, indicator_id, knowledge_date_to]
           unique: false
       odapi:
+        measure:
+          base: zahl
         indicator: 1
         period_type: duedate
         period_code: year
@@ -26,6 +28,8 @@ models:
         - columns: [geo_code, indicator_id, knowledge_date_to]
           unique: false
       odapi:
+        measure:
+          base: zahl
         indicator: 2
         period_type: duedate
         period_code: year
@@ -41,6 +45,8 @@ models:
         - columns: [geo_code, indicator_id, knowledge_date_to]
           unique: false
       odapi:
+        measure:
+          base: zahl
         indicators:
           - indicator_id: 95
           - indicator_id: 96
@@ -64,6 +70,8 @@ models:
         - columns: [geo_code, indicator_id, knowledge_date_to]
           unique: false
       odapi:
+        measure:
+          base: zahl
         indicators:
           - indicator_id: 106
           - indicator_id: 107
@@ -86,6 +94,8 @@ models:
         - columns: [geo_code, indicator_id, knowledge_date_to]
           unique: false
       odapi:
+        measure:
+          base: zahl
         indicators:
           - indicator_id: 111
           - indicator_id: 112
@@ -3422,3 +3432,20 @@ models:
             filter_and:
               - column: beobachtungseinheit
                 regex: "^Beschäftigte.*"
+
+  # ---------------------------------------------------------------------------
+  - name: intm_swisstopo_zweitwohnung
+    tests:
+      - odapi_intm_pk_groups
+      - odapi_intm_columns
+      - odapi_intm_rowsmin
+    config:
+      odapi:
+        measure:
+          base: zahl
+        indicators:
+          - indicator_id: 101
+          - indicator_id: 102
+          - indicator_id: 103
+          - indicator_id: 104
+          - indicator_id: 105

--- a/models/models/intermediate/ktzh/intm_ktzh_gp_auslaenderanteil__measure.sql
+++ b/models/models/intermediate/ktzh/intm_ktzh_gp_auslaenderanteil__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/ktzh/intm_ktzh_gp_auslaenderanteil__typecast.sql
+++ b/models/models/intermediate/ktzh/intm_ktzh_gp_auslaenderanteil__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/ktzh/intm_ktzh_gp_bevoelkerung__measure.sql
+++ b/models/models/intermediate/ktzh/intm_ktzh_gp_bevoelkerung__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/ktzh/intm_ktzh_gp_bevoelkerung__typecast.sql
+++ b/models/models/intermediate/ktzh/intm_ktzh_gp_bevoelkerung__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/intermediate/swisstopo/intm_swisstopo_zweitwohnung.sql
+++ b/models/models/intermediate/swisstopo/intm_swisstopo_zweitwohnung.sql
@@ -163,5 +163,4 @@ select
     , meas.indicator_value_text::TEXT
     , meas.source::TEXT
     , 1::SMALLINT as _etl_version
-    , 'zahl'::TEXT as measure_code
 from union_all meas

--- a/models/models/intermediate/swisstopo/intm_swisstopo_zweitwohnung__measure.sql
+++ b/models/models/intermediate/swisstopo/intm_swisstopo_zweitwohnung__measure.sql
@@ -1,0 +1,1 @@
+{{ intm_measures() }}

--- a/models/models/intermediate/swisstopo/intm_swisstopo_zweitwohnung__typecast.sql
+++ b/models/models/intermediate/swisstopo/intm_swisstopo_zweitwohnung__typecast.sql
@@ -1,0 +1,1 @@
+{{ intm_typecast() }}

--- a/models/models/marts/full_mart_ogd_api.sql
+++ b/models/models/marts/full_mart_ogd_api.sql
@@ -1,53 +1,5 @@
-
-select
-    indicator_id
-    , geo_code
-    , geo_value
-    , knowledge_date_from
-    , knowledge_date_to
-    , period_type
-    , period_code
-    , period_ref_from
-    , period_ref
-    , group_1.group_id as group_1_id
-    , group_value_1.group_value_id as group_value_1_id
-    , case
-        when coalesce(group_value_1.group_value_id, 1) = 1 then TRUE
-        else FALSE
-    end as _group_value_1_is_total
-    , group_2.group_id as group_2_id
-    , group_value_2.group_value_id as group_value_2_id
-    , case
-        when coalesce(group_value_2.group_value_id, 1) = 1 then TRUE
-        else FALSE
-    end as _group_value_2_is_total
-    , group_3.group_id as group_3_id
-    , group_value_3.group_value_id as group_value_3_id
-    , case
-        when coalesce(group_value_3.group_value_id, 1) = 1 then TRUE
-        else FALSE
-    end as _group_value_3_is_total
-    , group_4.group_id as group_4_id
-    , group_value_4.group_value_id as group_value_4_id
-    , case
-        when coalesce(group_value_4.group_value_id, 1) = 1 then TRUE
-        else FALSE
-    end as _group_value_4_is_total
-    , measure_code
-    , indicator_value_numeric::NUMERIC(32, 9)  -- this is a limit from COPY TO PARQUET
-    , indicator_value_text
-    , dim.id as source_id
-from {{ source('marts', 'mart_ogd_api') }} data
-    left join {{ ref('dim_source') }} dim on data.source = dim.source
-    left join {{ ref('dim_group') }} group_1 on data.group_1_name = group_1.group_name
-    left join {{ ref('dim_group') }} group_2 on data.group_2_name = group_2.group_name
-    left join {{ ref('dim_group') }} group_3 on data.group_3_name = group_3.group_name
-    left join {{ ref('dim_group') }} group_4 on data.group_4_name = group_4.group_name
-    left join {{ ref('dim_group_value') }} group_value_1 on
-        data.group_1_value = group_value_1.group_value_name
-    left join {{ ref('dim_group_value') }} group_value_2 on
-        data.group_2_value = group_value_2.group_value_name
-    left join {{ ref('dim_group_value') }} group_value_3 on
-        data.group_3_value = group_value_3.group_value_name
-    left join {{ ref('dim_group_value') }} group_value_4 on
-        data.group_4_value = group_value_4.group_value_name
+-- this model exists only to use the same
+-- grans logic like for other dbt models
+-- these grants are used by the downsrem API
+select *
+from {{ source('marts', 'mart_ogd_api') }}

--- a/models/models/marts/mart_bfe_minergie.sql
+++ b/models/models/marts/mart_bfe_minergie.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_0019jahre.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_0019jahre.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_2039jahre.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_2039jahre.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_2064jahre.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_2064jahre.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_65plusjahre.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_65plusjahre.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_altersquotient.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_altersquotient.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_gesamtquotient.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_gesamtquotient.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_greyingindex.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_greyingindex.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_altersstruktur_jugendquotient.sql
+++ b/models/models/marts/mart_bfs_statatlas_altersstruktur_jugendquotient.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_kultur.sql
+++ b/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_kultur.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_sektor1.sql
+++ b/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_sektor1.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_sektor2.sql
+++ b/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_sektor2.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_sektor3.sql
+++ b/models/models/marts/mart_bfs_statatlas_arbeitsstaetten_sektor3.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_auslaender_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_auslaender_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_auslaenderanteil_deutsche.sql
+++ b/models/models/marts/mart_bfs_statatlas_auslaenderanteil_deutsche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_auslaenderanteil_eu.sql
+++ b/models/models/marts/mart_bfs_statatlas_auslaenderanteil_eu.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_auslaenderanteil_franzoesisch.sql
+++ b/models/models/marts/mart_bfs_statatlas_auslaenderanteil_franzoesisch.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_auslaenderanteil_staendig.sql
+++ b/models/models/marts/mart_bfs_statatlas_auslaenderanteil_staendig.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_bau_gebaeude_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_bau_gebaeude_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_bau_wohnung_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_bau_wohnung_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_beschaeftigte_betriebswirtschaft.sql
+++ b/models/models/marts/mart_bfs_statatlas_beschaeftigte_betriebswirtschaft.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_beschaeftigte_kultur.sql
+++ b/models/models/marts/mart_bfs_statatlas_beschaeftigte_kultur.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_beschaeftigte_sektor1.sql
+++ b/models/models/marts/mart_bfs_statatlas_beschaeftigte_sektor1.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_beschaeftigte_sektor2.sql
+++ b/models/models/marts/mart_bfs_statatlas_beschaeftigte_sektor2.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_beschaeftigte_sektor3.sql
+++ b/models/models/marts/mart_bfs_statatlas_beschaeftigte_sektor3.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_bestand_arbeitsplaetze.sql
+++ b/models/models/marts/mart_bfs_statatlas_bestand_arbeitsplaetze.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_bestand_unternehmen.sql
+++ b/models/models/marts/mart_bfs_statatlas_bestand_unternehmen.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_bevoelkerungsdichte_gesamt.sql
+++ b/models/models/marts/mart_bfs_statatlas_bevoelkerungsdichte_gesamt.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_bevoelkerungsdichte_produktiv.sql
+++ b/models/models/marts/mart_bfs_statatlas_bevoelkerungsdichte_produktiv.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_bewohner_efh.sql
+++ b/models/models/marts/mart_bfs_statatlas_bewohner_efh.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_biblio.sql
+++ b/models/models/marts/mart_bfs_statatlas_biblio.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_binnen_wanderungssaldo_p1000.sql
+++ b/models/models/marts/mart_bfs_statatlas_binnen_wanderungssaldo_p1000.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_efh.sql
+++ b/models/models/marts/mart_bfs_statatlas_efh.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_einbuergerungen.sql
+++ b/models/models/marts/mart_bfs_statatlas_einbuergerungen.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_einbuergerungen_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_einbuergerungen_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_einwohner_staendig.sql
+++ b/models/models/marts/mart_bfs_statatlas_einwohner_staendig.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_elektroautos_anteil.sql
+++ b/models/models/marts/mart_bfs_statatlas_elektroautos_anteil.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_elektroautos_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_elektroautos_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_geb_energiequelle.sql
+++ b/models/models/marts/mart_bfs_statatlas_geb_energiequelle.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_geb_gas.sql
+++ b/models/models/marts/mart_bfs_statatlas_geb_gas.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_geb_heizoel.sql
+++ b/models/models/marts/mart_bfs_statatlas_geb_heizoel.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_geb_waermepumpe.sql
+++ b/models/models/marts/mart_bfs_statatlas_geb_waermepumpe.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_gebaeudeareal_gesamt.sql
+++ b/models/models/marts/mart_bfs_statatlas_gebaeudeareal_gesamt.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_geburten.sql
+++ b/models/models/marts/mart_bfs_statatlas_geburten.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_geburtenueberschuss.sql
+++ b/models/models/marts/mart_bfs_statatlas_geburtenueberschuss.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_gymi_anteil.sql
+++ b/models/models/marts/mart_bfs_statatlas_gymi_anteil.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_haushalt_1pax.sql
+++ b/models/models/marts/mart_bfs_statatlas_haushalt_1pax.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_haushalt_2pax.sql
+++ b/models/models/marts/mart_bfs_statatlas_haushalt_2pax.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_haushalt_3pax.sql
+++ b/models/models/marts/mart_bfs_statatlas_haushalt_3pax.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_haushalt_4pax.sql
+++ b/models/models/marts/mart_bfs_statatlas_haushalt_4pax.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_haushalt_5pluspax.sql
+++ b/models/models/marts/mart_bfs_statatlas_haushalt_5pluspax.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_haushaltsgroesse.sql
+++ b/models/models/marts/mart_bfs_statatlas_haushaltsgroesse.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_heiraten_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_heiraten_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_industrieareal.sql
+++ b/models/models/marts/mart_bfs_statatlas_industrieareal.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_int_wanderungssaldo_p1000.sql
+++ b/models/models/marts/mart_bfs_statatlas_int_wanderungssaldo_p1000.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_kino_sitzplaetze.sql
+++ b/models/models/marts/mart_bfs_statatlas_kino_sitzplaetze.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_kinokomplexe.sql
+++ b/models/models/marts/mart_bfs_statatlas_kinokomplexe.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_kinos.sql
+++ b/models/models/marts/mart_bfs_statatlas_kinos.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_kinosaele.sql
+++ b/models/models/marts/mart_bfs_statatlas_kinosaele.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_kinosaele_3d.sql
+++ b/models/models/marts/mart_bfs_statatlas_kinosaele_3d.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_kuenstlich_angelegt.sql
+++ b/models/models/marts/mart_bfs_statatlas_kuenstlich_angelegt.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_landwirtschaftsflaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_landwirtschaftsflaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_lwz.sql
+++ b/models/models/marts/mart_bfs_statatlas_lwz.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_multiplexkino.sql
+++ b/models/models/marts/mart_bfs_statatlas_multiplexkino.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_museen.sql
+++ b/models/models/marts/mart_bfs_statatlas_museen.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_neu_arbeitsplaetze.sql
+++ b/models/models/marts/mart_bfs_statatlas_neu_arbeitsplaetze.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_neu_unternehmen.sql
+++ b/models/models/marts/mart_bfs_statatlas_neu_unternehmen.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_pendler_bilanz.sql
+++ b/models/models/marts/mart_bfs_statatlas_pendler_bilanz.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_pendler_saldo.sql
+++ b/models/models/marts/mart_bfs_statatlas_pendler_saldo.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_scheidungen_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_scheidungen_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_schliessung_arbeitsplaetze.sql
+++ b/models/models/marts/mart_bfs_statatlas_schliessung_arbeitsplaetze.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_schliessung_unternehmen.sql
+++ b/models/models/marts/mart_bfs_statatlas_schliessung_unternehmen.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_siedlungsflaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_siedlungsflaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_sozialhilfe_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_sozialhilfe_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_tax_reineinkommen_einwohner.sql
+++ b/models/models/marts/mart_bfs_statatlas_tax_reineinkommen_einwohner.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_tax_reineinkommen_steuerpflichtig.sql
+++ b/models/models/marts/mart_bfs_statatlas_tax_reineinkommen_steuerpflichtig.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_tax_reineinkommen_total.sql
+++ b/models/models/marts/mart_bfs_statatlas_tax_reineinkommen_total.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_tax_steuerbar_einwohner.sql
+++ b/models/models/marts/mart_bfs_statatlas_tax_steuerbar_einwohner.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_tax_steuerbar_steuerpflichtig.sql
+++ b/models/models/marts/mart_bfs_statatlas_tax_steuerbar_steuerpflichtig.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_tax_steuerbar_total.sql
+++ b/models/models/marts/mart_bfs_statatlas_tax_steuerbar_total.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_todesfaelle_anzahl.sql
+++ b/models/models/marts/mart_bfs_statatlas_todesfaelle_anzahl.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_unproduktivflaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_unproduktivflaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_vegetationslose_flaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_vegetationslose_flaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_verkehrsflaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_verkehrsflaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_versiegelte_flaeche_anteil.sql
+++ b/models/models/marts/mart_bfs_statatlas_versiegelte_flaeche_anteil.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_waldflaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_waldflaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_wanderungssaldo_p1000.sql
+++ b/models/models/marts/mart_bfs_statatlas_wanderungssaldo_p1000.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_wasserflaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_wasserflaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_whg_energiequelle.sql
+++ b/models/models/marts/mart_bfs_statatlas_whg_energiequelle.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_whg_gas.sql
+++ b/models/models/marts/mart_bfs_statatlas_whg_gas.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_whg_heizoel.sql
+++ b/models/models/marts/mart_bfs_statatlas_whg_heizoel.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_whg_waermepumpe.sql
+++ b/models/models/marts/mart_bfs_statatlas_whg_waermepumpe.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_wohnflaeche.sql
+++ b/models/models/marts/mart_bfs_statatlas_wohnflaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_bfs_statatlas_zi34.sql
+++ b/models/models/marts/mart_bfs_statatlas_zi34.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_estv_db_jp.sql
+++ b/models/models/marts/mart_estv_db_jp.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_estv_db_np.sql
+++ b/models/models/marts/mart_estv_db_np.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_ktzh_gp_auslaenderanteil.sql
+++ b/models/models/marts/mart_ktzh_gp_auslaenderanteil.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_ktzh_gp_bevoelkerung.sql
+++ b/models/models/marts/mart_ktzh_gp_bevoelkerung.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_arbeit_grenzgaenger.sql
+++ b/models/models/marts/mart_stab_arbeit_grenzgaenger.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bau_ausgaben.sql
+++ b/models/models/marts/mart_stab_bau_ausgaben.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bev_altersklasse.sql
+++ b/models/models/marts/mart_stab_bev_altersklasse.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bev_demografisch_bilanz.sql
+++ b/models/models/marts/mart_stab_bev_demografisch_bilanz.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bev_geburtsort.sql
+++ b/models/models/marts/mart_stab_bev_geburtsort.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bev_heirat.sql
+++ b/models/models/marts/mart_stab_bev_heirat.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bev_scheidung.sql
+++ b/models/models/marts/mart_stab_bev_scheidung.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bev_zivilstand.sql
+++ b/models/models/marts/mart_stab_bev_zivilstand.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_bev_zuwegzug.sql
+++ b/models/models/marts/mart_stab_bev_zuwegzug.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_geb_bestand.sql
+++ b/models/models/marts/mart_stab_geb_bestand.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_geb_flaeche.sql
+++ b/models/models/marts/mart_stab_geb_flaeche.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_geb_leerwhg.sql
+++ b/models/models/marts/mart_stab_geb_leerwhg.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_lw_beschaeftigte.sql
+++ b/models/models/marts/mart_stab_lw_beschaeftigte.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_raum_areal.sql
+++ b/models/models/marts/mart_stab_raum_areal.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_raum_noas.sql
+++ b/models/models/marts/mart_stab_raum_noas.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_wirtschaft_beschaeftigte.sql
+++ b/models/models/marts/mart_stab_wirtschaft_beschaeftigte.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_stab_wirtschaft_unternehmen.sql
+++ b/models/models/marts/mart_stab_wirtschaft_unternehmen.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/mart_swisstopo_zweitwohnung.sql
+++ b/models/models/marts/mart_swisstopo_zweitwohnung.sql
@@ -1,0 +1,1 @@
+{{ mart_partition() }}

--- a/models/models/marts/marts.yml
+++ b/models/models/marts/marts.yml
@@ -3,41 +3,14 @@ x-default-group: &default-group marts
 models:
   # ---------------------------------------------------------------------------
   - name: full_mart_ogd_api
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       materialized: view
       grants:
         select: ["odapi_public"]
-      #indexes:
-      #  - columns: [geo_code, geo_value]
-      #    unique: false
-      #  - columns: [geo_code, geo_value, knowledge_date_from, knowledge_date_to]
-      #    unique: false
-      #  - columns: [geo_code, geo_value, period_ref]
-      #    unique: false
-      #  - columns: [geo_code, geo_value]
-      #    unique: false
-      #  - columns: [geo_code, geo_value, knowledge_date_from, knowledge_date_to]
-      #    unique: false
-      #  - columns: [geo_code, geo_value, knowledge_date_to, _group_value_1_is_total, _group_value_2_is_total,
-      #      _group_value_3_is_total, _group_value_4_is_total]
-      #    unique: false
-      #  - columns: [geo_code, indicator_id]
-      #    unique: false
-      #  - columns: [geo_code, indicator_id, period_ref]
-      #    unique: false
-      #  - columns: [geo_code, indicator_id, knowledge_date_to]
-      #    unique: false
-      #  - columns: [geo_code, indicator_id, knowledge_date_to, _group_value_1_is_total, _group_value_2_is_total,
-      #      _group_value_3_is_total, _group_value_4_is_total]
-      #    unique: false
-      #  - columns: [geo_code, indicator_id, knowledge_date_from, knowledge_date_to]
-      #    unique: false
 
   # ---------------------------------------------------------------------------
   - name: mart_available_indicator
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       grants:
@@ -45,7 +18,6 @@ models:
 
   # ---------------------------------------------------------------------------
   - name: dim_gemeinde
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       indexes:
@@ -56,7 +28,6 @@ models:
 
   # ---------------------------------------------------------------------------
   - name: dim_gemeinde_latest
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       indexes:
@@ -67,7 +38,6 @@ models:
 
   # ---------------------------------------------------------------------------
   - name: dim_bezirk
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       indexes:
@@ -78,7 +48,6 @@ models:
 
   # ---------------------------------------------------------------------------
   - name: dim_bezirk_latest
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       indexes:
@@ -89,7 +58,6 @@ models:
 
   # ---------------------------------------------------------------------------
   - name: dim_kanton
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       indexes:
@@ -100,7 +68,6 @@ models:
 
   # ---------------------------------------------------------------------------
   - name: dim_kanton_latest
-    # ---------------------------------------------------------------------------
     config:
       group: *default-group
       indexes:
@@ -111,33 +78,105 @@ models:
 
   # ---------------------------------------------------------------------------
   - name: dim_source
-    # ---------------------------------------------------------------------------
     config:
+      contract: { enforced: true }
       group: *default-group
       indexes:
         - columns: [id]
           unique: true
+        - columns: [source]
+          unique: true
       grants:
         select: ["odapi_public"]
+    columns:
+      - name: id
+        data_type: smallint
+        constraints:
+          - type: primary_key
+      - name: source
+        data_type: text
+        constraints:
+          - type: not_null
+          # prevents row explosion on MART models, RAM usage on
+          # mart_stab_geb_flaeche reduces from 46GB to 18 GB
+          - type: unique
 
   # ---------------------------------------------------------------------------
   - name: dim_group
-    # ---------------------------------------------------------------------------
     config:
+      contract: { enforced: true }
       group: *default-group
       indexes:
         - columns: [group_id]
           unique: true
+        - columns: [group_name]
+          unique: true
       grants:
         select: ["odapi_public"]
+    columns:
+      - name: group_id
+        data_type: smallint
+        constraints:
+          - type: primary_key
+      - name: group_name
+        data_type: text
+        constraints:
+          - type: not_null
+          # prevents row explosion on MART models, RAM usage on
+          # mart_stab_geb_flaeche reduces from 46GB to 18 GB
+          - type: unique
 
   # ---------------------------------------------------------------------------
   - name: dim_group_value
-    # ---------------------------------------------------------------------------
     config:
+      contract: { enforced: true }
       group: *default-group
       indexes:
         - columns: [group_value_id]
           unique: true
+        - columns: [group_value_name]
+          unique: true
       grants:
         select: ["odapi_public"]
+    columns:
+      - name: group_value_id
+        data_type: smallint
+        constraints:
+          - type: primary_key
+      - name: group_value_name
+        data_type: text
+        constraints:
+          - type: not_null
+          # prevents row explosion on MART models, RAM usage on
+          # mart_stab_geb_flaeche reduces from 46GB to 18 GB
+          - type: unique
+
+  # ---------------------------------------------------------------------------
+  - name: mart_stab_geb_flaeche
+    config:
+      # RAM hungry model, finetuning Postgres settings
+      # Disabled hashjoin and hashagg which will cause the RAM to explode
+      # But instead, i big tempfile is needed (postgres will use a file on disk instead)
+      pre_hook:
+        - "SET LOCAL work_mem = '3GB'"
+        - "SET LOCAL hash_mem_multiplier = 1.0"
+        - "SET LOCAL max_parallel_workers_per_gather = 0"
+        - "SET LOCAL enable_hashjoin = off" # force merge/nested loop (spills instead of RAM blowups)
+        - "SET LOCAL enable_hashagg = off"
+        - "SET LOCAL temp_file_limit = '60GB'"
+        - "SET LOCAL jit = on"
+
+  # ---------------------------------------------------------------------------
+  - name: mart_stab_geb_bestand
+    config:
+      # RAM hungry model, finetuning Postgres settings
+      # Disabled hashjoin and hashagg which will cause the RAM to explode
+      # But instead, i big tempfile is needed (postgres will use a file on disk instead)
+      pre_hook:
+        - "SET LOCAL work_mem = '3GB'"
+        - "SET LOCAL hash_mem_multiplier = 1.0"
+        - "SET LOCAL max_parallel_workers_per_gather = 0"
+        - "SET LOCAL enable_hashjoin = off" # force merge/nested loop (spills instead of RAM blowups)
+        - "SET LOCAL enable_hashagg = off"
+        - "SET LOCAL temp_file_limit = '60GB'"
+        - "SET LOCAL jit = on"

--- a/models/tests/generic/intm.sql
+++ b/models/tests/generic/intm.sql
@@ -23,7 +23,6 @@
     'indicator_value_text',
     'source',
     '_etl_version',
-    'measure_code',
 ] %}
 {{ return(default__expect_table_columns_to_match_ordered_list(model, column_list, transform)) }}
 {% endtest %}
@@ -33,12 +32,12 @@
 -- GLOBAL PK
 --------------------------------------------------------------------------------
 {% test odapi_intm_pk_nogroups(model) %}
-    {% set combination_of_columns = ['indicator_id', 'geo_code', 'geo_value', 'period_ref', 'knowledge_date_from', 'measure_code'] %}
+    {% set combination_of_columns = ['indicator_id', 'geo_code', 'geo_value', 'period_ref', 'knowledge_date_from'] %}
     {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns=False)) }}
 {% endtest %}
 
 {% test odapi_intm_pk_groups(model) %}
-    {% set combination_of_columns = ['indicator_id', 'geo_code', 'geo_value', 'period_ref', 'knowledge_date_from', 'group_1_value', 'group_2_value', 'group_3_value', 'group_4_value', 'measure_code'] %}
+    {% set combination_of_columns = ['indicator_id', 'geo_code', 'geo_value', 'period_ref', 'knowledge_date_from', 'group_1_value', 'group_2_value', 'group_3_value', 'group_4_value'] %}
     {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns=False)) }}
 {% endtest %}
 
@@ -53,7 +52,7 @@
         model,
         min_value=2000,
         max_value=None,
-        group_by=['period_ref', 'measure_code'],
+        group_by=['period_ref'],
         row_condition="geo_code = 'polg' and knowledge_date_to is NULL",
         strictly=False,
     ) }}

--- a/models/tests/generic/statatlas/statatlas_intm.sql
+++ b/models/tests/generic/statatlas/statatlas_intm.sql
@@ -2,6 +2,6 @@
 -- AND multiple SCD-Type2 validities.
 -- Indicator should already be selected.
 {% test statatlas_intm_pk(model) %}
-    {% set combination_of_columns = ['geo_code', 'geo_value', 'period_ref', 'knowledge_date_from', 'measure_code'] %}
+    {% set combination_of_columns = ['geo_code', 'geo_value', 'period_ref', 'knowledge_date_from'] %}
     {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns=False)) }}
 {% endtest %}


### PR DESCRIPTION
Refactored INTM models with indicator data.

Previously, all INTM logic was done in one single model, with multiple appended macros. If something went wrong, this structure was difficult to debug.

The INTM models now have the following structure:

  1. intm_: First INTM model which brings the various data sources into a similar structure. All config to ODAPI are stored in the corresponding model config of this model. Downstream models read from this config.
  2. intm_*__measure: Calculates the measures as provided by the intm_ model config.
  3. intm_*__typecast: Converts all columns into the desired data types, which makes it possible to then generate a partition table for mart_ogd_api
  4. mart_: Replaces text values for group, group_values and sources to IDs of the corrensponding DIM table.

A script has been written to automatically generate all intm_*__measure, intm_*__typecast and mart_ models automatically, once the config and modlel for intm_ has been written:

    create_intm_dunder_models.sh

Disk usage:
All INTM models are now materialized as views. Only the mart_ models (which act as partition for mart_ogd_api) and the snapshot tables are materialized as table. This helps to save storage in the future.

Additionally, data on mart_ gets normalized and replaced with IDs, so that it takes less space while materializing as table.

Closes #97 