### PR TITLE
fix(dag): sensor timing when modified in future

### DIFF
--- a/dag/odapi/assets/bfs/opendataswiss.py
+++ b/dag/odapi/assets/bfs/opendataswiss.py
@@ -161,7 +161,13 @@ def pipeline_factory(ckan_resource: CkanResource) -> tuple:
         )
         assert isinstance(last_modified, dt.datetime)
 
-        if last_modified > last_execution:
+        if last_modified > dt.datetime.now(tz=dt.timezone.utc):
+            yield SkipReason(
+                'Result: '
+                f'last modified {last_modified} is set in the future. '
+                'Skip.'
+            )
+        elif last_modified > last_execution:
             yield RunRequest(job_name=ckan_resource.job_name_web)
         else:
             yield SkipReason(


### PR DESCRIPTION
Fixed sensor timing, when the modified information in the ckan resource is after the current time. Sometimes, modified is set to the future by mistake. Without this fix, the sensor would trigger a run every time.